### PR TITLE
Adding the kill task.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-test:
-	./node_modules/.bin/mocha test/* 
+tests:
+	./node_modules/.bin/mocha -R spec test/* 
 
 .PHONY: all test clean

--- a/lib/sinatra.js
+++ b/lib/sinatra.js
@@ -42,16 +42,14 @@ module.exports.start = function(args, options) {
 };
 
 module.exports.kill = function(args, options){
-  if(_currentProcess) {
-    console.log("the current process ID is: " + _currentProcess.pid)
-    process.kill(pid, 'SIGKILL');
-  } else {
+  if(!_currentProcess) {
     var _pidFile = options.pidFile;
-
-    console.log("the current process ID is: " +_pidFile + fs.existsSync(_pidFile))
     if(fs.existsSync(_pidFile)) {
-    console.log("the current process ID is: " + fs.readFileSync(_pidFile))
-      process.kill(fs.readFileSync(_pidFile), 'SIGKILL');
+      pid = fs.readFileSync(_pidFile);
     }
   }
+  console.log("Killing the process: " + pid);
+  process.kill(pid, 'SIGKILL');
+  pid = undefined;
+  fs.unlinkSync(options.pidFile);
 };

--- a/lib/sinatra.js
+++ b/lib/sinatra.js
@@ -41,16 +41,17 @@ module.exports.start = function(args, options) {
   console.log("Sinatra server started on port 9292. PID: " + pid );
 };
 
-module.exports.kill = function(options){
+module.exports.kill = function(args, options){
   if(_currentProcess) {
-    _currentProcess.kill('QUIT');
+    console.log("the current process ID is: " + _currentProcess.pid)
+    process.kill(pid, 'SIGKILL');
   } else {
-    if(grunt.file.exists(_pidFile)) {
-      args = ['-s', 'QUIT', grunt.file.read(_pidFile)];
-    }
-    spawn('kill', args, {
-      stdio: 'inherit'
-    });
-  }
+    var _pidFile = options.pidFile;
 
-}
+    console.log("the current process ID is: " +_pidFile + fs.existsSync(_pidFile))
+    if(fs.existsSync(_pidFile)) {
+    console.log("the current process ID is: " + fs.readFileSync(_pidFile))
+      process.kill(fs.readFileSync(_pidFile), 'SIGKILL');
+    }
+  }
+};

--- a/lib/sinatra.js
+++ b/lib/sinatra.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var spawn = require('child_process').spawn;
+var spawn = require('child_process').spawn,
+               fs = require('fs'),
+     mkdirp = require('mkdirp'),
+          path = require('path');
 
 var _currentProcess;
 var pid;
@@ -31,6 +34,10 @@ module.exports.start = function(args, options) {
   });
 
   pid = _currentProcess.pid;
+  mkdirp(path.dirname(options.pidFile), function (err){
+    if(err){ throw(err) }
+  });
+  fs.writeFileSync(options.pidFile, pid);
   console.log("Sinatra server started on port 9292. PID: " + pid );
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-sinatra",
   "description": "Control your sinatra server via Grunt",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/vjustov/grunt-sinatra",
   "author": {
     "name": "Viktor Justo",
@@ -25,7 +25,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "make tests"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
     "gruntplugin", "sinatra", "rack", "server", "ruby"
   ],
   "dependencies": {
+    "mkdirp": "~0.5.0"
   }
 }

--- a/tasks/sinatra.js
+++ b/tasks/sinatra.js
@@ -23,27 +23,27 @@ module.exports = function(grunt) {
     command = command || 'start';
 
     var args = [];
+    var opts = this.options();
+    opts.pidFile = opts.pidFile || "/tmp/sinatraServer.pid";
 
-    var options = this.options();
-
-    if(grunt.util._.has(options, "port")) {
-      args.push("-p", options.port);
+    if(grunt.util._.has(opts, "port")) {
+      args.push("-p", opts.port);
     }
 
-    if(grunt.util._.has(options, "daemon")) {
+    if(grunt.util._.has(opts, "daemon")) {
       args.push("--daemonize");
     }
 
-    if(grunt.util._.has(options, "debugger")) {
+    if(grunt.util._.has(opts, "debugger")) {
       args.push("--debug");
     }
 
-    if(grunt.util._.has(options, "environment")) {
-      args.push("--env", options.environment);
+    if(grunt.util._.has(opts, "environment")) {
+      args.push("--env", opts.environment);
     }
 
-    if(grunt.util._.has(options, "pid")) {
-      args.push("--pid", options.pid);
+    if(grunt.util._.has(opts, "pid")) {
+      args.push("--pid", opts.pid);
       //_pidFile = options.pid;
     }
 

--- a/test/sinatra.js
+++ b/test/sinatra.js
@@ -1,8 +1,13 @@
 var should = require("should"),
     running = require("is-running"),
-    sinatra = require("../lib/sinatra");
+      sinatra = require("../lib/sinatra");
 
 describe("grunt-sinatra", function(){
+  var args = [];
+  var opts = {
+    pidFile: "/tmp/sinatraServer.pid"
+  }
+
   it("should run the server", function(){
     //code here
     sinatra.start();
@@ -10,9 +15,12 @@ describe("grunt-sinatra", function(){
   });
 
   it("should kill the server", function(){
-    running(sinatra.pid()).should.equal(true);
-    sinatra.kill();
-    running(sinatra.pid()).should.equal(false);
+    var pid = sinatra.pid();
+    running(pid).should.equal(true);
+    sinatra.kill(args, opts);
+    setTimeout(function(){
+      running(pid).should.equal(false);
+    }, 500);
   });
 
   it("should restart a running server");

--- a/test/sinatra.js
+++ b/test/sinatra.js
@@ -8,9 +8,9 @@ describe("grunt-sinatra", function(){
     pidFile: "/tmp/sinatraServer.pid"
   }
 
-  it("should run the server", function(){
+  it("should start the server", function(){
     //code here
-    sinatra.start();
+    sinatra.start(args, opts);
     running(sinatra.pid()).should.equal(true);
   });
 


### PR DESCRIPTION
Running sinatra:kill will now kill any sinatra process created by grunt or anyother one as long as you specify the .pid file.
